### PR TITLE
added flag for disabling the configuration of firewalld if necessary

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -76,3 +76,5 @@ redis_disabled_commands: []
 #  - SREM
 #  - RENAME
 #  - SHUTDOWN
+
+configure_firewalld: true

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -27,7 +27,9 @@
     state: present
 
 - name: Ensure firewalld is running.
-  when: ansible_connection != 'docker'
+  when:
+    - ansible_connection != 'docker'
+    - configure_firewalld
   systemd:
     name: firewalld
     daemon-reload: true

--- a/tasks/sentinel.yml
+++ b/tasks/sentinel.yml
@@ -27,6 +27,7 @@
   when:
     - redis_sentinel is defined
     - ansible_connection != 'docker'
+    - configure_firewalld
   firewalld:
     port: "{{ redis_sentinel_port }}/tcp"
     permanent: true

--- a/tasks/server.yml
+++ b/tasks/server.yml
@@ -23,7 +23,9 @@
   notify: restart redis
 
 - name: Firewalld configuration redis-server
-  when: ansible_connection != 'docker'
+  when:
+    - ansible_connection != 'docker'
+    - configure_firewalld
   firewalld:
     port: "{{ redis_port }}/tcp"
     permanent: true


### PR DESCRIPTION
The servers we were deploying this towards did not utilize firewalld. This PR adds a flag to allow skipping the firewalld configuration steps for such scenarios.